### PR TITLE
A possible way to allow item to allocate objects that require parameters in the constructor

### DIFF
--- a/src/DummyItem.cpp
+++ b/src/DummyItem.cpp
@@ -3,17 +3,23 @@
 
 using namespace std;
 
-//envire::core::DummyClass::DummyClass(int number)
-//{
-//    cout << "Constructor of the Item with one argument" << endl;
-//}
+envire::core::DummyClass::DummyClass(const int& number)
+{
+    id = number;
+    cout << "Constructor of the Item with one argument" << endl;
+}
 
 void envire::core::DummyClass::welcome()
 {
     cout << "This is a method of the class to which the template fits" << endl;
+    cout << "My id is: " << id << endl;
 }
-//// Inheritance from a template fitting the DummyClass type
+int envire::core::DummyClass::getId(){
+    return this -> id;
+}
+// Inheritance from a template fitting the DummyClass type
 void envire::core::DummyItem::hello()
 {
     cout << "You successfully created a class that inherited from a template. Hello!" << endl;
 }
+

--- a/src/DummyItem.cpp
+++ b/src/DummyItem.cpp
@@ -3,10 +3,22 @@
 
 using namespace std;
 
+envire::core::DummyClass::DummyClass()
+{
+    cout << "Constructor of the DummyClass with no argument" << endl;
+}
+
 envire::core::DummyClass::DummyClass(const int& number)
 {
     id = number;
-    cout << "Constructor of the Item with one argument" << endl;
+    cout << "Constructor of the DummyClass with one argument" << endl;
+}
+
+envire::core::DummyClass::DummyClass(const int& number, const std::vector<double>& vector)
+{
+    id = number;
+    myVector = vector;
+    cout << "Constructor of the DummyClass with various arguments" << endl;
 }
 
 void envire::core::DummyClass::welcome()
@@ -14,8 +26,13 @@ void envire::core::DummyClass::welcome()
     cout << "This is a method of the class to which the template fits" << endl;
     cout << "My id is: " << id << endl;
 }
-int envire::core::DummyClass::getId(){
+int envire::core::DummyClass::getId()
+{
     return this -> id;
+}
+std::vector<double> envire::core::DummyClass::getMyVector()
+{
+    return this -> myVector;
 }
 // Inheritance from a template fitting the DummyClass type
 void envire::core::DummyItem::hello()

--- a/src/DummyItem.hpp
+++ b/src/DummyItem.hpp
@@ -54,22 +54,21 @@ namespace envire{
     {
       public: 
         int id;
-        // TEST:
-        // If the constructor of the allocated class requires an argument the
-        // base class fails on instantiation.
-        //
-        // To test uncomment the next line:
-        DummyClass(const int& id);
+        std::vector<double> myVector;
+        DummyClass();
+        DummyClass(const int& number);
+        DummyClass(const int& number, const std::vector<double>& vector);
         void welcome();
         int getId();
+        std::vector<double> getMyVector();
     };
     // Inheritance from a template fitting the DummyClass type
     class DummyItem : public Item<DummyClass> {
       //protected:
       //  envire::core::DummyClass user_data;
       public: 
-        template <typename Ts>                                                      
-          DummyItem(Ts&& args) : Item<DummyClass> (std::forward<Ts>(args)){}
+        template <typename... Ts>                                                      
+          DummyItem(Ts&&... args) : Item<DummyClass> (std::forward<Ts>(args)...){}
         // Overriding the constructor like this is not possible.
         //DummyItem() : Item() {
         //  user_data = DummyClass(1);

--- a/src/DummyItem.hpp
+++ b/src/DummyItem.hpp
@@ -53,13 +53,15 @@ namespace envire{
     class DummyClass 
     {
       public: 
+        int id;
         // TEST:
         // If the constructor of the allocated class requires an argument the
         // base class fails on instantiation.
         //
         // To test uncomment the next line:
-        DummyClass(const int& id){};
+        DummyClass(const int& id);
         void welcome();
+        int getId();
     };
     // Inheritance from a template fitting the DummyClass type
     class DummyItem : public Item<DummyClass> {

--- a/src/DummyItem.hpp
+++ b/src/DummyItem.hpp
@@ -58,7 +58,7 @@ namespace envire{
         // base class fails on instantiation.
         //
         // To test uncomment the next line:
-        //DummyClass(int);
+        DummyClass(const int& id){};
         void welcome();
     };
     // Inheritance from a template fitting the DummyClass type
@@ -66,6 +66,8 @@ namespace envire{
       //protected:
       //  envire::core::DummyClass user_data;
       public: 
+        template <typename Ts>                                                      
+          DummyItem(Ts&& args) : Item<DummyClass> (std::forward<Ts>(args)){}
         // Overriding the constructor like this is not possible.
         //DummyItem() : Item() {
         //  user_data = DummyClass(1);

--- a/src/Item.hpp
+++ b/src/Item.hpp
@@ -3,6 +3,7 @@
 
 #include <envire_core/ItemBase.hpp>
 #include <class_loader/class_loader.h>
+#include <utility>                                                              
 
 /**
  * ** Envire marcos **
@@ -75,6 +76,12 @@ namespace envire { namespace core
         {
             user_data_ptr = &user_data;
         };
+
+        template <typename Ts>
+        Item(Ts&& args) : user_data(std::forward<Ts>(args))
+        {
+            user_data_ptr = &user_data;
+        }; 
 
         /**@brief setData
         *

--- a/src/Item.hpp
+++ b/src/Item.hpp
@@ -77,8 +77,8 @@ namespace envire { namespace core
             user_data_ptr = &user_data;
         };
 
-        template <typename Ts>
-        Item(Ts&& args) : user_data(std::forward<Ts>(args))
+        template <typename... Ts>
+        Item(Ts&&... args) : user_data(std::forward<Ts>(args)...)
         {
             user_data_ptr = &user_data;
         }; 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,7 +9,6 @@ rock_testsuite(test_suite suite.cpp
     test_transform_tree.cpp
     test_labeled_transform_tree.cpp
     test_boundary.cpp
-    test_dummy_item.cpp
     DEPS_CMAKE Boost
     DEPS envire_core
     DEPS_PKGCONFIG class_loader)
@@ -18,4 +17,8 @@ rock_testsuite(test_dummy suite.cpp
     test_dummy_graph.cpp
     test_property_tag.cpp)
 
+rock_testsuite(test_parameter_forwarding suite.cpp
+    test_dummy_item.cpp
+    DEPS_CMAKE Boost
+    DEPS envire_core)
 

--- a/test/test_dummy_item.cpp
+++ b/test/test_dummy_item.cpp
@@ -13,7 +13,12 @@ BOOST_AUTO_TEST_CASE(contructors)
     //envire::core::DummyItem item(1);
     std::cout << "Constructor Test Done" << std::endl;
 }
-
+BOOST_AUTO_TEST_CASE(contructor_no_parameters)
+{
+    std::cout << "TEST: Constructor With Parameters: No parameters Test" << std::endl;
+    DummyItem item;
+    DummyClass dummy_object = item.getData();
+}
 BOOST_AUTO_TEST_CASE(contructor_parameters_forwarding)
 {
     std::cout << "TEST: Constructor With Parameters Forwarding Test" << std::endl;
@@ -21,4 +26,15 @@ BOOST_AUTO_TEST_CASE(contructor_parameters_forwarding)
     DummyItem item(id);
     DummyClass dummy_object = item.getData();
     assert(id==dummy_object.getId());
+}
+BOOST_AUTO_TEST_CASE(contructor_various_parameters_forwarding)
+{
+    std::cout << "TEST: Constructor With Various Parameters Forwarding Test" << std::endl;
+    int id = 1;
+    static const int arr[] = {0,10,10};
+    std::vector<double> vector(arr, arr + sizeof(arr) / sizeof(arr[0]) );
+    DummyItem item(id, vector);
+    DummyClass dummy_object = item.getData();
+    assert(id==dummy_object.getId());
+    assert(vector==dummy_object.getMyVector());
 }

--- a/test/test_dummy_item.cpp
+++ b/test/test_dummy_item.cpp
@@ -1,20 +1,24 @@
 #include <boost/test/unit_test.hpp>
 #include <iostream>
 #include <envire_core/DummyItem.hpp>
+#include <assert.h>
+
+using namespace envire::core;
 
 BOOST_AUTO_TEST_CASE(contructors)
 {
-    envire::core::Item<DummyClass> item(1);
+    std::cout << "TEST: Constructor With Parameters Instantiation Test" << std::endl;
+    Item<DummyClass> item(1);
     //envire::core::Item<DummyClass> item;
     //envire::core::DummyItem item(1);
     std::cout << "Constructor Test Done" << std::endl;
 }
 
-BOOST_AUTO_TEST_CASE(welcome)
+BOOST_AUTO_TEST_CASE(contructor_parameters_forwarding)
 {
-    envire::core::DummyClass dummy_object(1);
-    dummy_object.welcome();
-    envire::core::DummyItem item(1);
-    item.setData(dummy_object);
-    std::cout << "Set data Test Done" << std::endl;
+    std::cout << "TEST: Constructor With Parameters Forwarding Test" << std::endl;
+    int id = 1;
+    DummyItem item(id);
+    DummyClass dummy_object = item.getData();
+    assert(id==dummy_object.getId());
 }

--- a/test/test_dummy_item.cpp
+++ b/test/test_dummy_item.cpp
@@ -4,15 +4,17 @@
 
 BOOST_AUTO_TEST_CASE(contructors)
 {
-    envire::core::DummyItem item;
+    envire::core::Item<DummyClass> item(1);
+    //envire::core::Item<DummyClass> item;
+    //envire::core::DummyItem item(1);
     std::cout << "Constructor Test Done" << std::endl;
 }
 
 BOOST_AUTO_TEST_CASE(welcome)
 {
-    envire::core::DummyClass dummy_object;
+    envire::core::DummyClass dummy_object(1);
     dummy_object.welcome();
-    envire::core::DummyItem item;
+    envire::core::DummyItem item(1);
     item.setData(dummy_object);
     std::cout << "Set data Test Done" << std::endl;
 }


### PR DESCRIPTION
Some objects that are stored in the Item class might need parameters in the constructor. This commit includes the changes in Item.hpp to allow so and also a small test.