### PR TITLE
Fix random generator creation in Frame ctor

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,7 @@ rock_library(envire_core
             ClassLoader.hpp
             AlignedBoundingBox.hpp
             DummyItem.hpp
+            RandomGenerator.hpp
     SOURCES ItemBase.cpp
             ClassLoader.cpp
             BoundingVolume.cpp

--- a/src/Frame.hpp
+++ b/src/Frame.hpp
@@ -8,6 +8,7 @@
 #include <string>
 
 #include <envire_core/ItemBase.hpp>
+#include <envire_core/RandomGenerator.hpp>
 
 namespace envire { namespace core
 {
@@ -23,24 +24,24 @@ namespace envire { namespace core
         std::vector< boost::intrusive_ptr<ItemBase> > items; /** List of items in the node */
 
     public:
-        Frame():name("envire::core::noname"), uuid(boost::uuids::random_generator()()){};
-        Frame(const std::string &_name):name(_name),uuid(boost::uuids::random_generator()()){};
-        ~Frame(){ this->items.clear(); };
+        Frame() : name("envire::core::noname"),
+            uuid(RandomGenerator::getRandomGenerator()()) {}
+        Frame(const std::string &_name): 
+            name(_name), uuid(RandomGenerator::getRandomGenerator()()) {}
+
+        ~Frame(){ this->items.clear(); }
 
         /**@brief setFrame
         *
         * Sets the frame name of the item
-        *
         */
         void setName(const std::string& name) { this->name = name; }
 
         /**@brief getFrame
         *
         * Returns the frame name of the item
-        *
         */
         const std::string& getName() const { return this->name; }
-
-   };
+    };
 }}
 #endif

--- a/src/ItemBase.cpp
+++ b/src/ItemBase.cpp
@@ -1,6 +1,5 @@
 #include "ItemBase.hpp"
-
-#include <boost/uuid/uuid_generators.hpp>
+#include <envire_core/RandomGenerator.hpp>
 
 using namespace envire::core;
 
@@ -9,6 +8,6 @@ const std::string ItemBase::class_name = "envire::core::ItemBase";
 void envire::core::intrusive_ptr_add_ref( ItemBase* item ) { item->ref_count++; }
 void envire::core::intrusive_ptr_release( ItemBase* item ) { if(!--item->ref_count) delete item; }
 
-ItemBase::ItemBase() : ref_count(0), time(base::Time::now()), uuid(boost::uuids::random_generator()()), user_data_ptr(NULL)
+ItemBase::ItemBase() : ref_count(0), time(base::Time::now()), uuid(RandomGenerator::getRandomGenerator()()), user_data_ptr(NULL)
 {
 }

--- a/src/RandomGenerator.hpp
+++ b/src/RandomGenerator.hpp
@@ -1,0 +1,35 @@
+/**
+ * \file RandomGenerator.hpp
+ * \author Arne Boeckmann
+ */
+
+#ifndef RANDOMGENERATOR_HPP
+#define RANDOMGENERATOR_HPP
+
+#include <boost/thread/tss.hpp>
+#include <boost/uuid/random_generator.hpp>
+
+namespace envire { namespace core
+{
+    /**A singleton that provides access to a thread local random_generator
+     * for uuid creation. */
+    class RandomGenerator 
+    {
+    public: 
+        /**Returns a reference to a thread local random_generator that can be
+         * used for uuid creation */
+        static boost::uuids::random_generator& getRandomGenerator()
+        {
+            //boost::uuids::random_generator is not thread safe. I.e. calling it
+            //from multiple threads may cause duplicate ids. Therefore thread_specific_ptr
+            //is used.
+            static boost::thread_specific_ptr<boost::uuids::random_generator> randGen;
+            if(!randGen.get()) {
+                randGen.reset(new boost::uuids::random_generator());
+            }
+            return *randGen;
+        }
+    };
+}}
+#endif	/* RANDOMGENERATOR_HPP */
+

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,6 +9,7 @@ rock_testsuite(test_suite suite.cpp
     test_transform_tree.cpp
     test_labeled_transform_tree.cpp
     test_boundary.cpp
+    test_frame.cpp
     DEPS_CMAKE Boost
     DEPS envire_core
     DEPS_PKGCONFIG class_loader)

--- a/test/test_frame.cpp
+++ b/test/test_frame.cpp
@@ -1,0 +1,12 @@
+#include <boost/test/unit_test.hpp>
+#include <envire_core/Frame.hpp>
+
+using envire::core::Frame;
+using boost::uuids::uuid;
+
+BOOST_AUTO_TEST_CASE(uuid_test)
+{
+    Frame f;
+    BOOST_ASSERT(f.uuid.version() == uuid::version_random_number_based);
+    BOOST_ASSERT(!f.uuid.is_nil());
+}


### PR DESCRIPTION
Before, every time a new Frame was created it also created a new random_generator.
Now one random_generator per thread is created and reused.

Also added a very tiny test that ensures that the uuid is generated and not null