### PR TITLE
Search transform

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,8 @@ rock_library(envire_core
             Environment.hpp
             TransformGraph.hpp
             TransformGraphTypes.hpp
+            TransformGraphExceptions.hpp
+            TransformGraphVisitors.hpp
             GraphViz.hpp
             SpatialItem.hpp
             BoundingVolume.hpp

--- a/src/Transform.hpp
+++ b/src/Transform.hpp
@@ -19,10 +19,33 @@ namespace envire { namespace core
         Transform() { this->transform.invalidateTransform(); };
         Transform(const base::Time &_time):time(_time)
         { this->transform.invalidateTransform(); };
+        Transform(const base::Time &_time, const base::TransformWithCovariance &_twc):
+            time(_time), transform(_twc){};
+
+
+        Transform(const Transform &_transform)
+        {
+            this->time = _transform.time;
+            this->transform = _transform.transform;
+        }
 
         void setTransform(const base::TransformWithCovariance& tf)
         {
             this->transform = tf;
+        }
+
+        Transform operator*(const Transform &tf) const
+        {
+            base::Time last_time;
+            if(this->time > tf.time)
+            {
+                last_time = this->time;
+            }
+            else
+            {
+                last_time = tf.time;
+            }
+            return Transform(this->time, this->transform*tf.transform);
         }
 
     };

--- a/src/TransformGraph.cpp
+++ b/src/TransformGraph.cpp
@@ -48,12 +48,8 @@ void TransformGraph::addTransform(const FrameId& origin, const FrameId& target,
     edge_descriptor targetToOrigin = add_edge(targetDesc, originDesc, invTf);
 }
 
-const Transform& TransformGraph::getTransform(const FrameId& a, const FrameId& b) const
+const Transform TransformGraph::getTransform(const FrameId& a, const FrameId& b) const
 {
-    vertex_descriptor origin_frame = vertex(a);
-    vertex_descriptor target_frame = vertex(b);
-    envire::core::TransformGraphBFSVisitor <vertex_descriptor>vis(origin_frame, this->graph());
-
     //calling boost::edge_by_label on an empty graph results in a segfault.
     //therefore catch it before that happens.
     if(num_edges() == 0)
@@ -62,10 +58,50 @@ const Transform& TransformGraph::getTransform(const FrameId& a, const FrameId& b
     }
 
     //direct edges
-    edgePair pair = boost::edge_by_label(a, b, *this);
+    edgePair pair;
+    pair = boost::edge_by_label(a, b, *this);
     if(!pair.second)
     {
-        throw UnknownTransformException(a, b);
+        /** It is not a direct edge transformation **/
+        Transform tf;
+        vertex_descriptor origin_frame = vertex(a);
+        vertex_descriptor target_frame = vertex(b);
+        envire::core::TransformGraphBFSVisitor <vertex_descriptor>visit(target_frame, this->graph());
+
+        // check whether the vertices exist in the graph
+        // search algorithm result on segfault in case some of the vertices do not exist
+        if (origin_frame == null_vertex() || target_frame == null_vertex())
+        {
+            throw UnknownTransformException(a, b);
+        }
+
+        try
+        {
+            boost::breadth_first_search(this->graph(), origin_frame, visitor(visit));
+
+        }catch(const FoundFrameException &e)
+        {
+            //std::cout<< e.what() << std::endl;
+            base::TransformWithCovariance &trans(tf.transform);
+
+            /** Compute the transformation **/
+            trans.setTransform (base::Affine3d::Identity());
+            std::deque<vertex_descriptor>::iterator it = visit.tree->begin();
+            for (; (it+1) != visit.tree->end(); ++it)
+            {
+                pair = boost::edge(*it, *(it+1), graph());
+                trans = trans * (*this)[pair.first].transform.transform;
+            }
+        }
+
+        if(tf.transform.hasValidTransform())
+        {
+            return tf;
+        }
+        else
+        {
+            throw UnknownTransformException(a, b);
+        }
     }
 
     return (*this)[pair.first].transform;

--- a/src/TransformGraph.cpp
+++ b/src/TransformGraph.cpp
@@ -50,18 +50,24 @@ void TransformGraph::addTransform(const FrameId& origin, const FrameId& target,
 
 const Transform& TransformGraph::getTransform(const FrameId& a, const FrameId& b) const
 {
+    vertex_descriptor origin_frame = vertex(a);
+    vertex_descriptor target_frame = vertex(b);
+    envire::core::TransformGraphBFSVisitor <vertex_descriptor>vis(origin_frame, this->graph());
+
     //calling boost::edge_by_label on an empty graph results in a segfault.
     //therefore catch it before that happens.
     if(num_edges() == 0)
     {
         throw UnknownTransformException(a, b);
     }
-    //FIXME for now this only works with direct edges
+
+    //direct edges
     edgePair pair = boost::edge_by_label(a, b, *this);
     if(!pair.second)
     {
         throw UnknownTransformException(a, b);
     }
+
     return (*this)[pair.first].transform;
 }
 
@@ -144,7 +150,7 @@ edges_size_type TransformGraph::num_edges() const
 
 vertex_descriptor TransformGraph::add_vertex(const FrameId& frameId)
 {
-    FrameProperty node_prop;
+    FrameProperty node_prop(frameId);
     vertex_descriptor v = LabeledTransformGraph::add_vertex(frameId, node_prop);
     return v;
 }

--- a/src/TransformGraph.hpp
+++ b/src/TransformGraph.hpp
@@ -92,7 +92,7 @@ namespace envire { namespace core
 
         /** @return the transform between a and b. Calculating it if necessary.
          * @throw UnknownTransformException if the transformation doesn't exist*/
-        const Transform& getTransform(const FrameId& a, const FrameId& b) const;
+        const Transform getTransform(const FrameId& a, const FrameId& b) const;
 
         /** @return the edge between frame @p origin and @p target
          * @throw UnknownTransformException if there is no such edge  */

--- a/src/TransformGraph.hpp
+++ b/src/TransformGraph.hpp
@@ -8,8 +8,8 @@
  */
 
 
-#ifndef __ENVIRE_CORE_TRANSFORM_TREE__
-#define __ENVIRE_CORE_TRANSFORM_TREE__
+#ifndef __ENVIRE_CORE_TRANSFORM_GRAPH__
+#define __ENVIRE_CORE_TRANSFORM_GRAPH__
 
 
 #include <boost/uuid/uuid.hpp>
@@ -18,7 +18,8 @@
 
 
 #include "TransformGraphTypes.hpp"
-#include "TransformTreeExceptions.hpp"
+#include "TransformGraphExceptions.hpp"
+#include "TransformGraphVisitors.hpp"
 #include "events/GraphEventPublisher.hpp"
 #include "events/TransformAddedEvent.hpp"
 #include "events/TransformRemovedEvent.hpp"
@@ -100,15 +101,15 @@ namespace envire { namespace core
         /** @return a reference to the frame identified by the id.
          *  @throw UnknownFrameException if the frame id is invalid **/
         const envire::core::Frame& getFrame(const FrameId& frame);
-        
+
         /** Adds @p item to the item list of the specified frame 
          *  @throw UnknownFrameException if the frame id is invalid **/
         void addItemToFrame(const FrameId& frame, boost::intrusive_ptr<ItemBase> item);
-        
+
         /** @return a list of items that are attached to the specified @p frame.
          *  @throw UnknownFrameException if the @p frame id is invalid.*/
         const std::vector<boost::intrusive_ptr<ItemBase>>& getItems(const FrameId& frame) const;
-        
+
 
         vertices_size_type num_vertices() const;
         edges_size_type num_edges() const;

--- a/src/TransformGraphExceptions.hpp
+++ b/src/TransformGraphExceptions.hpp
@@ -1,5 +1,5 @@
 /*
- * TransformTreeExceptions.hpp
+ * TransformGraphExceptions.hpp
  *
  *  Created on: Sep 22, 2015
  *      Author: aboeckmann
@@ -39,6 +39,16 @@ namespace envire { namespace core
         virtual char const * what() const throw() { return msg.c_str(); }
         const std::string msg;
     };
+
+    class FoundFrameException : public std::exception
+    {
+    public:
+        FoundFrameException(const FrameId& name) :
+          msg("Found Frame " + name) {}
+        virtual char const * what() const throw() { return msg.c_str(); }
+        const std::string msg;
+    };
+
 
 }}
 

--- a/src/TransformGraphTypes.hpp
+++ b/src/TransformGraphTypes.hpp
@@ -14,7 +14,7 @@
 
 #include "Frame.hpp" /** Frames are for the Vertex **/
 #include "Transform.hpp" /** Transform are the Edges **/
-#include "Environment.hpp" /** Environment is the tree property **/
+#include "Environment.hpp" /** Environment is the graph property **/
 
 #include <boost/graph/directed_graph.hpp>
 
@@ -35,6 +35,8 @@ namespace envire { namespace core
     struct FrameProperty
     {
         Frame frame;
+        FrameProperty(){}
+        FrameProperty(const FrameId& frameId): frame(Frame(frameId)){}
     };
 
     /**@brief Transform Property

--- a/src/TransformGraphVisitors.hpp
+++ b/src/TransformGraphVisitors.hpp
@@ -1,0 +1,45 @@
+/*
+ * TransformGraphExceptions.hpp
+ *
+ *  Created on: Sep 22, 2015
+ *      Author: jhidalgo
+ */
+
+#pragma once
+#include <boost/graph/breadth_first_search.hpp>
+
+namespace envire { namespace core
+{
+
+    template < typename Vertex >
+    class TransformGraphBFSVisitor: public boost::default_bfs_visitor
+    {
+    public:
+        template <typename Graph>
+        TransformGraphBFSVisitor(Vertex &v, Graph &g):vertex_to_origin(v)
+        {parent.resize(g.num_vertices());}
+
+        template <typename Graph>
+        void examine_vertex(Vertex v, const Graph &g)
+        {
+            std::cout<<"EXAMINE["<<g[v].frame.name<<"]\n";
+        }
+
+        template < typename Edge, typename Graph>
+        void tree_edge(Edge e, const Graph &g)
+        {
+            Vertex source_vertex = boost::source(e, g);
+            Vertex target_vertex = boost::target(e, g);
+            //parent[target_vertex] = source_vertex;
+
+            std::cout<<"EDGE"<<g[source_vertex].frame.name<<"->"<<g[target_vertex].frame.name<<"\n";
+        }
+
+
+
+    public:
+        Vertex vertex_to_origin;
+        std::vector<Vertex> parent;
+    };
+}}
+

--- a/src/TransformGraphVisitors.hpp
+++ b/src/TransformGraphVisitors.hpp
@@ -6,40 +6,80 @@
  */
 
 #pragma once
+#include "TransformGraphExceptions.hpp"
+#include <boost/shared_ptr.hpp>
 #include <boost/graph/breadth_first_search.hpp>
+
+#include <deque>
+#include <unordered_map>
 
 namespace envire { namespace core
 {
 
-    template < typename Vertex >
+    class Empty{};
+
+    template < typename Vertex>
     class TransformGraphBFSVisitor: public boost::default_bfs_visitor
     {
     public:
         template <typename Graph>
-        TransformGraphBFSVisitor(Vertex &v, Graph &g):vertex_to_origin(v)
-        {parent.resize(g.num_vertices());}
+        TransformGraphBFSVisitor(const Vertex &v,const Graph &g):vertex_to_search(v)
+        {
+            parent.reset(new std::unordered_map<Vertex,Vertex>());
+            tree.reset(new std::deque<Vertex>());
+        }
 
         template <typename Graph>
-        void examine_vertex(Vertex v, const Graph &g)
+        void discover_vertex(Vertex v, const Graph &g)
         {
-            std::cout<<"EXAMINE["<<g[v].frame.name<<"]\n";
+            if (vertex_to_search == v)
+            {
+                Vertex parent_vertex = v;
+
+                /** Get its direct parent **/
+                while (parent_vertex != Graph::null_vertex())
+                {
+                    tree->push_front(parent_vertex);
+                    try
+                    {
+                        parent_vertex = parent->at(parent_vertex);
+                    }catch (const std::out_of_range& oor)
+                    {
+                        parent_vertex = Graph::null_vertex();
+                    }
+                }
+
+                throw FoundFrameException(g[v].frame.name);
+            }
         }
+
 
         template < typename Edge, typename Graph>
         void tree_edge(Edge e, const Graph &g)
         {
             Vertex source_vertex = boost::source(e, g);
             Vertex target_vertex = boost::target(e, g);
-            //parent[target_vertex] = source_vertex;
-
-            std::cout<<"EDGE"<<g[source_vertex].frame.name<<"->"<<g[target_vertex].frame.name<<"\n";
+            parent->insert(std::make_pair<Vertex,Vertex>(static_cast<Vertex>(target_vertex), static_cast<Vertex>(source_vertex)));
         }
 
 
 
     public:
-        Vertex vertex_to_origin;
-        std::vector<Vertex> parent;
+        Vertex vertex_to_search;
+        boost::shared_ptr< std::unordered_map<Vertex, Vertex> > parent;
+        boost::shared_ptr< std::deque<Vertex> > tree; /** tree from origin tree[0] to target tree[n] */
     };
+
+
+    /** TESTING BOOST CODE **/
+    template < class Visitor=boost::null_visitor>
+    class TransformGraphBFSRecorderVisitor: public boost::bfs_visitor<Visitor>
+    {
+    public:
+        TransformGraphBFSRecorderVisitor():boost::bfs_visitor<>(){ }
+        TransformGraphBFSRecorderVisitor(Visitor record_vis):boost::bfs_visitor<Visitor>(record_vis){ }
+
+    };
+
 }}
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,3 +23,19 @@ rock_testsuite(test_parameter_forwarding suite.cpp
     test_dummy_item.cpp
     DEPS_CMAKE Boost
     DEPS envire_core)
+
+rock_executable(dfs_test dfs_test.cpp
+    DEPS_CMAKE Boost
+	DEPS envire_core)
+
+rock_executable(bfs_test bfs_test.cpp
+    DEPS_CMAKE Boost
+	DEPS envire_core)
+
+rock_executable(dijkstra_color_test dijkstra_color_test.cpp
+    DEPS_CMAKE Boost
+	DEPS envire_core)
+
+rock_executable(dijkstra_test dijkstra_test.cpp
+    DEPS_CMAKE Boost
+	DEPS envire_core)

--- a/test/bfs_test.cpp
+++ b/test/bfs_test.cpp
@@ -1,0 +1,152 @@
+//=======================================================================
+// Copyright 2001 Jeremy G. Siek, Andrew Lumsdaine, Lie-Quan Lee, 
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//=======================================================================
+#include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/breadth_first_search.hpp>
+#include <boost/pending/indirect_cmp.hpp>
+#include <boost/range/iterator_range.hpp>
+
+#include <iostream>
+
+using namespace boost;
+template < typename TimeMap, typename VertexMap >
+class bfs_time_visitor:public default_bfs_visitor {
+  typedef typename property_traits < TimeMap >::value_type T;
+public:
+  bfs_time_visitor(TimeMap tmap, VertexMap v, T & t):m_timemap(tmap), vertex_to_search(v), m_time(t)
+    {
+        vertex_map.insert(std::pair<long unsigned int, const char>(0, 'r'));
+        vertex_map.insert(std::pair<long unsigned int, const char>(1, 's'));
+        vertex_map.insert(std::pair<long unsigned int, const char>(2, 't'));
+        vertex_map.insert(std::pair<long unsigned int, const char>(3, 'u'));
+        vertex_map.insert(std::pair<long unsigned int, const char>(4, 'v'));
+        vertex_map.insert(std::pair<long unsigned int, const char>(5, 'w'));
+        vertex_map.insert(std::pair<long unsigned int, const char>(6, 'x'));
+        vertex_map.insert(std::pair<long unsigned int, const char>(7, 'y'));
+    }
+
+    struct found_vertex {};
+
+  template < typename Vertex, typename Graph >
+    void discover_vertex(Vertex u, const Graph & g)
+  {
+    put(m_timemap, u, m_time++);
+    if (u == vertex_to_search)
+    {
+        std::cout<<"FOUND("<<vertex_map[u]<<")\n";
+        //throw found_vertex();
+    }
+    else
+    {
+        std::cout<<"STILL_TO_DISCOVER("<<vertex_map[u]<<")\n";
+    }
+  }
+
+   template < typename Vertex, typename Graph >
+    void finish_vertex(Vertex u, const Graph & g)
+  {
+    std::cout<<"NO FOUND("<<vertex_map[u]<<")\n";
+  }
+
+   template < typename Edge, typename Graph >
+    void tree_edge(Edge e, const Graph & g)
+  {
+      VertexMap source_vertex = boost::source(e, g);
+      VertexMap target_vertex = boost::target(e, g);
+
+      std::cout<<"EDGE: "<<vertex_map[source_vertex]<<"->"<<vertex_map[target_vertex]<<"\n";
+
+  }
+
+
+  TimeMap m_timemap;
+  VertexMap vertex_to_search;
+  T & m_time;
+  std::map<long unsigned int, const char> vertex_map;
+
+};
+
+
+int
+main()
+{
+  using namespace boost;
+  // Select the graph type we wish to use
+  typedef adjacency_list < vecS, vecS, undirectedS > graph_t;
+  // Set up the vertex IDs and names
+  enum { r, s, t, u, v, w, x, y, N };
+  const char *name = "rstuvwxy";
+  // Specify the edges in the graph
+  typedef std::pair < int, int >E;
+  E edge_array[] = { E(r, s), E(r, v), E(s, w), E(w, r), E(w, t),
+    E(w, x), E(x, t), E(t, u), E(x, y), E(u, y)
+  };
+  // Create the graph object
+  const int n_edges = sizeof(edge_array) / sizeof(E);
+#if defined(BOOST_MSVC) && BOOST_MSVC <= 1300
+  // VC++ has trouble with the edge iterator constructor
+  graph_t g(N);
+  for (std::size_t j = 0; j < n_edges; ++j)
+    add_edge(edge_array[j].first, edge_array[j].second, g);
+#else
+  typedef graph_traits<graph_t>::vertices_size_type v_size_t;
+  graph_t g(edge_array, edge_array + n_edges, v_size_t(N));
+#endif
+
+  // Typedefs
+  typedef graph_traits < graph_t >::vertex_descriptor Vertex;
+  typedef graph_traits < graph_t >::vertices_size_type Size;
+  typedef Size* Iiter;
+
+  // a vector to hold the discover time property for each vertex
+  std::vector < Size > dtime(num_vertices(g));
+
+  Size time = 0;
+  bfs_time_visitor < Size *, Vertex>vis(&dtime[0], vertex(x, g), time);
+  std::vector<Vertex> p(num_vertices(g));
+
+  try
+  {
+    breadth_first_search(g, vertex(s, g), visitor(vis));
+  }catch(...)
+  {
+      std::cout<<"YIPUUU!!\n";
+  }
+
+  // Use std::sort to order the vertices by their discover time
+  std::vector<graph_traits<graph_t>::vertices_size_type > discover_order(N);
+  auto range = boost::irange(0, 8);
+  std::copy(range.begin(), range.end(), discover_order.begin());
+  std::sort(discover_order.begin(), discover_order.end(),
+            indirect_cmp < Iiter, std::less < Size > >(&dtime[0]));
+
+  std::cout << "order of discovery: ";
+  for (int i = 0; i < N; ++i)
+    std::cout << name[discover_order[i]] << " ";
+  std::cout << std::endl;
+
+
+  breadth_first_search(g, vertex(s, g),
+    visitor(make_bfs_visitor(record_predecessors(&p[0], on_tree_edge()))));
+
+  std::cout << "Path:" << std::endl;
+  Vertex v_target = vertex(y, g);
+  Vertex v_source = vertex(s, g);
+  Vertex v_current = v_target;
+  std::cout<<name[v_current];
+  while (v_source != v_current)
+  {
+      v_current = p[v_current];
+
+      std::cout<<"<-"<<name[v_current];
+  }
+  std::cout<<"\n";
+
+
+
+  return EXIT_SUCCESS;
+}

--- a/test/dfs_test.cpp
+++ b/test/dfs_test.cpp
@@ -1,0 +1,94 @@
+//=======================================================================
+// Copyright 2001 Jeremy G. Siek, Andrew Lumsdaine, Lie-Quan Lee, 
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//=======================================================================
+#include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/depth_first_search.hpp>
+#include <boost/range/iterator_range.hpp>
+#include <boost/pending/indirect_cmp.hpp>
+
+#include <iostream>
+
+using namespace boost;
+template < typename TimeMap > class dfs_time_visitor:public default_dfs_visitor {
+  typedef typename property_traits < TimeMap >::value_type T;
+public:
+  dfs_time_visitor(TimeMap dmap, TimeMap fmap, T & t)
+:  m_dtimemap(dmap), m_ftimemap(fmap), m_time(t) {
+  }
+  template < typename Vertex, typename Graph >
+    void discover_vertex(Vertex u, const Graph & g) const
+  {
+    put(m_dtimemap, u, m_time++);
+  }
+  template < typename Vertex, typename Graph >
+    void finish_vertex(Vertex u, const Graph & g) const
+  {
+    put(m_ftimemap, u, m_time++);
+  }
+  TimeMap m_dtimemap;
+  TimeMap m_ftimemap;
+  T & m_time;
+};
+
+
+int
+main()
+{
+  // Select the graph type we wish to use
+  typedef adjacency_list < vecS, vecS, directedS > graph_t;
+  typedef graph_traits < graph_t >::vertices_size_type size_type;
+  // Set up the vertex names
+  enum
+  { u, v, w, x, y, z, N };
+  char name[] = { 'u', 'v', 'w', 'x', 'y', 'z' };
+  // Specify the edges in the graph
+  typedef std::pair < int, int >E;
+  E edge_array[] = { E(u, v), E(u, x), E(x, v), E(y, x),
+    E(v, y), E(w, y), E(w, z), E(z, z)
+  };
+#if defined(BOOST_MSVC) && BOOST_MSVC <= 1300
+  graph_t g(N);  
+  for (std::size_t j = 0; j < sizeof(edge_array) / sizeof(E); ++j)
+    add_edge(edge_array[j].first, edge_array[j].second, g);
+#else
+  graph_t g(edge_array, edge_array + sizeof(edge_array) / sizeof(E), N);
+#endif
+
+  // Typedefs
+  typedef boost::graph_traits < graph_t >::vertex_descriptor Vertex;
+  typedef size_type* Iiter;
+
+  // discover time and finish time properties
+  std::vector < size_type > dtime(num_vertices(g));
+  std::vector < size_type > ftime(num_vertices(g));
+  size_type t = 0;
+  dfs_time_visitor < size_type * >vis(&dtime[0], &ftime[0], t);
+
+  depth_first_search(g, visitor(vis));
+
+  // use std::sort to order the vertices by their discover time
+  std::vector < size_type > discover_order(N);
+  auto r = boost::irange(0, 6);
+  std::copy(r.begin(), r.end(), discover_order.begin());
+  std::sort(discover_order.begin(), discover_order.end(),
+            indirect_cmp < Iiter, std::less < size_type > >(&dtime[0]));
+  std::cout << "order of discovery: ";
+  int i;
+  for (i = 0; i < N; ++i)
+    std::cout << name[discover_order[i]] << " ";
+
+  std::vector < size_type > finish_order(N);
+  std::copy(r.begin(), r.end(), finish_order.begin());
+  std::sort(finish_order.begin(), finish_order.end(),
+            indirect_cmp < Iiter, std::less < size_type > >(&ftime[0]));
+  std::cout << std::endl << "order of finish: ";
+  for (i = 0; i < N; ++i)
+    std::cout << name[finish_order[i]] << " ";
+  std::cout << std::endl;
+
+  return EXIT_SUCCESS;
+}

--- a/test/dijkstra_color_test.cpp
+++ b/test/dijkstra_color_test.cpp
@@ -1,0 +1,77 @@
+//=======================================================================
+// Copyright 2001 Jeremy G. Siek, Andrew Lumsdaine, Lie-Quan Lee, 
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//=======================================================================
+#include <boost/config.hpp>
+#include <iostream>
+#include <fstream>
+
+#include <boost/graph/graph_traits.hpp>
+#include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/dijkstra_shortest_paths.hpp>
+#include <boost/property_map/property_map.hpp>
+
+using namespace boost;
+
+int
+main(int, char *[])
+{
+  typedef adjacency_list < listS, vecS, directedS,
+    no_property, property < edge_weight_t, int > > graph_t;
+  typedef graph_traits < graph_t >::vertex_descriptor vertex_descriptor;
+  typedef std::pair<int, int> Edge;
+
+  const int num_nodes = 5;
+  enum nodes { A, B, C, D, E };
+  char name[] = "ABCDE";
+  Edge edge_array[] = { Edge(A, C), Edge(B, B), Edge(B, D), Edge(B, E),
+    Edge(C, B), Edge(C, D), Edge(D, E), Edge(E, A), Edge(E, B)
+  };
+  int weights[] = { 1, 2, 1, 2, 7, 3, 1, 1, 1 };
+  int num_arcs = sizeof(edge_array) / sizeof(Edge);
+  graph_t g(edge_array, edge_array + num_arcs, weights, num_nodes);
+  property_map<graph_t, edge_weight_t>::type weightmap = get(edge_weight, g);
+  std::vector<vertex_descriptor> p(num_vertices(g));
+  std::vector<int> d(num_vertices(g));
+  vertex_descriptor s = vertex(A, g);
+
+  dijkstra_shortest_paths(g, s,
+                          predecessor_map(boost::make_iterator_property_map(p.begin(), get(boost::vertex_index, g))).
+                          distance_map(boost::make_iterator_property_map(d.begin(), get(boost::vertex_index, g))));
+
+  std::cout << "distances and parents:" << std::endl;
+  graph_traits < graph_t >::vertex_iterator vi, vend;
+  for (boost::tie(vi, vend) = vertices(g); vi != vend; ++vi) {
+    std::cout << "distance(" << name[*vi] << ") = " << d[*vi] << ", ";
+    std::cout << "parent(" << name[*vi] << ") = " << name[p[*vi]] << std::
+      endl;
+  }
+  std::cout << std::endl;
+
+  std::ofstream dot_file("figs/dijkstra-eg.dot");
+
+  dot_file << "digraph D {\n"
+    << "  rankdir=LR\n"
+    << "  size=\"4,3\"\n"
+    << "  ratio=\"fill\"\n"
+    << "  edge[style=\"bold\"]\n" << "  node[shape=\"circle\"]\n";
+
+  graph_traits < graph_t >::edge_iterator ei, ei_end;
+  for (boost::tie(ei, ei_end) = edges(g); ei != ei_end; ++ei) {
+    graph_traits < graph_t >::edge_descriptor e = *ei;
+    graph_traits < graph_t >::vertex_descriptor
+      u = source(e, g), v = target(e, g);
+    dot_file << name[u] << " -> " << name[v]
+      << "[label=\"" << get(weightmap, e) << "\"";
+    if (p[v] == u)
+      dot_file << ", color=\"black\"";
+    else
+      dot_file << ", color=\"grey\"";
+    dot_file << "]";
+  }
+  dot_file << "}";
+  return EXIT_SUCCESS;
+}

--- a/test/dijkstra_test.cpp
+++ b/test/dijkstra_test.cpp
@@ -1,0 +1,134 @@
+//=======================================================================
+// Copyright 2001 Jeremy G. Siek, Andrew Lumsdaine, Lie-Quan Lee
+// Copyright 2009 Trustees of Indiana University.
+// Copyright 2001 Jeremy G. Siek, Andrew Lumsdaine, Lie-Quan Lee, 
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// NOTE: Based off of dijkstra-example.cpp
+//=======================================================================
+#include <boost/config.hpp>
+#include <iostream>
+#include <fstream>
+#include <cstring>
+
+#include <boost/graph/graph_traits.hpp>
+#include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/dijkstra_shortest_paths_no_color_map.hpp>
+#include <boost/property_map/property_map.hpp>
+
+using namespace boost;
+
+
+template < typename Vertex >
+struct threshold_visitor: boost::default_dijkstra_visitor {
+   double threshold;
+   Vertex vertex_to_search;
+   char name[6];
+   threshold_visitor(double threshold, Vertex v): threshold(threshold), vertex_to_search(v) {std::strcpy(name, "ABCDE");}
+
+   struct found_vertex {};
+   template < typename Graph >
+   void examine_vertex(Vertex v, const Graph& G)
+   {
+       std::cout<<"EXAMINE["<<name[v]<<"]\n";
+       if (vertex_to_search == v)
+       {
+           std::cout<<"FOUND!\n";
+           throw found_vertex();
+       }
+   }
+};
+
+int
+main(int, char *[])
+{
+  typedef adjacency_list < listS, vecS, directedS,
+    no_property, property < edge_weight_t, int > > graph_t;
+  typedef graph_traits < graph_t >::vertex_descriptor vertex_descriptor;
+  typedef std::pair<int, int> Edge;
+
+  const int num_nodes = 5;
+  enum nodes { A, B, C, D, E };
+  char name[] = "ABCDE";
+  Edge edge_array[] = { Edge(A, C), Edge(B, B), Edge(B, D), Edge(B, E),
+    Edge(C, B), Edge(C, D), Edge(D, E), Edge(E, A), Edge(E, B)
+  };
+  int weights[] = { 1, 1, 1, 1, 1, 1, 1, 1, 1 };
+  int num_arcs = sizeof(edge_array) / sizeof(Edge);
+  graph_t g(edge_array, edge_array + num_arcs, weights, num_nodes);
+  property_map<graph_t, edge_weight_t>::type weightmap = get(edge_weight, g);
+  std::vector<vertex_descriptor> p(num_vertices(g));
+  std::vector<int> d(num_vertices(g));
+  vertex_descriptor s = vertex(A, g);
+
+  try
+  {
+    dijkstra_shortest_paths_no_color_map(g, s,
+                                       predecessor_map(boost::make_iterator_property_map(p.begin(), get(boost::vertex_index, g))).
+                                       distance_map(boost::make_iterator_property_map(d.begin(), get(boost::vertex_index, g))).
+                                       visitor(threshold_visitor<vertex_descriptor>(1, vertex(B, g))));
+
+  }catch(...)
+  {
+      std::cout<<"YIPUUU!!\n";
+  }
+
+  std::cout << "distances and parents:" << std::endl;
+  graph_traits < graph_t >::vertex_iterator vi, vend;
+  for (boost::tie(vi, vend) = vertices(g); vi != vend; ++vi) {
+    std::cout << "distance(" << name[*vi] << ") = " << d[*vi] << ", ";
+    std::cout << "parent(" << name[*vi] << ") = " << name[p[*vi]] << std::
+      endl;
+  }
+  std::cout << "Vector:" << std::endl;
+  for (std::vector<vertex_descriptor>::iterator it=p.begin(); it != p.end(); it++)
+  {
+      std::cout<<"name: "<<name[*it]<<"\n";
+  }
+
+  std::cout << "Path:" << std::endl;
+  vertex_descriptor v_target = vertex(B, g);
+  vertex_descriptor v_source = vertex(A, g);
+  vertex_descriptor v_current = v_target;
+  std::cout<<name[v_current];
+  while (v_source != v_current)
+  {
+      v_current = p[v_current];
+
+      std::cout<<"<-"<<name[v_current];
+  }
+  std::cout<<"\n";
+
+
+
+  std::cout << std::endl;
+
+  std::ofstream dot_file("./dijkstra-no-color-map-eg.dot");
+
+  dot_file << "digraph D {\n"
+    << "  rankdir=LR\n"
+    << "  size=\"4,3\"\n"
+    << "  ratio=\"fill\"\n"
+    << "  edge[style=\"bold\"]\n" << "  node[shape=\"circle\"]\n";
+
+  graph_traits < graph_t >::edge_iterator ei, ei_end;
+  for (boost::tie(ei, ei_end) = edges(g); ei != ei_end; ++ei) {
+    graph_traits < graph_t >::edge_descriptor e = *ei;
+    graph_traits < graph_t >::vertex_descriptor
+      u = source(e, g), v = target(e, g);
+    dot_file << name[u] << " -> " << name[v]
+      << "[label=\"" << get(weightmap, e) << "\"";
+    if (p[v] == u)
+      dot_file << ", color=\"black\"";
+    else
+      dot_file << ", color=\"grey\"";
+    dot_file << "]";
+  }
+  dot_file << "}";
+
+  dot_file.close();
+  return EXIT_SUCCESS;
+}

--- a/test/dijkstra_visitor_test.cpp
+++ b/test/dijkstra_visitor_test.cpp
@@ -1,0 +1,250 @@
+//=======================================================================
+// Copyright 1997, 1998, 1999, 2000 University of Notre Dame.
+// Authors: Andrew Lumsdaine, Lie-Quan Lee, Jeremy G. Siek
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//=======================================================================
+#include <boost/config.hpp>
+#include <iostream>
+#include <iterator>
+#include <vector>
+#include <list>
+// Use boost::queue instead of std::queue because std::queue doesn't
+// model Buffer; it has to top() function. -Jeremy
+#include <boost/pending/queue.hpp>
+
+#include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/visitors.hpp>
+#include <boost/graph/breadth_first_search.hpp>
+#include <boost/graph/dijkstra_shortest_paths.hpp>
+#include <boost/graph/graph_utility.hpp>
+
+using namespace std;
+using namespace boost;
+/*
+  This example does a best-first-search (using dijkstra's) and
+  simultaneously makes a copy of the graph (assuming the graph is
+  connected).
+
+  Example Graph: (p. 90 "Data Structures and Network Algorithms", Tarjan)
+
+              g
+            3+ +2
+            / 1 \
+           e+----f
+           |+0 5++
+           | \ / |
+         10|  d  |12
+           |8++\7|
+           +/ | +|
+           b 4|  c
+            \ | +
+            6+|/3
+              a
+
+  Sample Output:
+a --> c d 
+b --> a d
+c --> f
+d --> c e f
+e --> b g
+f --> e g
+g -->
+Starting graph:
+a(32767); c d
+c(32767); f
+d(32767); c e f
+f(32767); e g
+e(32767); b g
+g(32767);
+b(32767); a d
+Result:
+a(0); d c
+d(4); f e c
+c(3); f
+f(9); g e
+e(4); g b
+g(7);
+b(14); d a 
+
+*/
+
+typedef property<vertex_color_t, default_color_type, 
+         property<vertex_distance_t,int> > VProperty;
+typedef int weight_t;
+typedef property<edge_weight_t,weight_t> EProperty;
+
+typedef adjacency_list<vecS, vecS, directedS, VProperty, EProperty > Graph;
+
+
+
+template <class Tag>
+struct endl_printer
+  : public boost::base_visitor< endl_printer<Tag> >
+{
+  typedef Tag event_filter;
+  endl_printer(std::ostream& os) : m_os(os) { }
+  template <class T, class Graph>
+  void operator()(T, Graph&) { m_os << std::endl; }
+  std::ostream& m_os;
+};
+template <class Tag>
+endl_printer<Tag> print_endl(std::ostream& os, Tag) {
+  return endl_printer<Tag>(os);
+}
+
+template <class PA, class Tag>
+struct edge_printer
+ : public boost::base_visitor< edge_printer<PA, Tag> >
+{
+  typedef Tag event_filter;
+
+  edge_printer(PA pa, std::ostream& os) : m_pa(pa), m_os(os) { }
+
+  template <class T, class Graph>
+  void operator()(T x, Graph& g) {
+    m_os << "(" << get(m_pa, source(x, g)) << "," 
+         << get(m_pa, target(x, g)) << ") ";
+  }
+  PA m_pa;
+  std::ostream& m_os;
+};
+template <class PA, class Tag>
+edge_printer<PA, Tag>
+print_edge(PA pa, std::ostream& os, Tag) {
+  return edge_printer<PA, Tag>(pa, os);
+}
+
+
+template <class NewGraph, class Tag>
+struct graph_copier 
+  : public boost::base_visitor<graph_copier<NewGraph, Tag> >
+{
+  typedef Tag event_filter;
+
+  graph_copier(NewGraph& graph) : new_g(graph) { }
+
+  template <class Edge, class Graph>
+  void operator()(Edge e, Graph& g) {
+    add_edge(source(e, g), target(e, g), new_g);
+  }
+private:
+  NewGraph& new_g;
+};
+template <class NewGraph, class Tag>
+inline graph_copier<NewGraph, Tag>
+copy_graph(NewGraph& g, Tag) {
+  return graph_copier<NewGraph, Tag>(g);
+}
+
+template <class Graph, class Name>
+void print(Graph& G, Name name)
+{
+  typename boost::graph_traits<Graph>::vertex_iterator ui, uiend;
+  for (boost::tie(ui, uiend) = vertices(G); ui != uiend; ++ui) {
+    cout << name[*ui] << " --> ";
+    typename boost::graph_traits<Graph>::adjacency_iterator vi, viend;
+    for(boost::tie(vi, viend) = adjacent_vertices(*ui, G); vi != viend; ++vi)
+      cout << name[*vi] << " ";
+    cout << endl;
+  }
+    
+}
+
+
+int 
+main(int , char* [])
+{
+  // Name and ID numbers for the vertices
+  char name[] = "abcdefg";
+  enum { a, b, c, d, e, f, g, N};
+
+  Graph G(N);
+  boost::property_map<Graph, vertex_index_t>::type 
+    vertex_id = get(vertex_index, G);
+
+  std::vector<weight_t> distance(N, (numeric_limits<weight_t>::max)());
+  typedef boost::graph_traits<Graph>::vertex_descriptor Vertex;
+  std::vector<Vertex> parent(N);
+
+  typedef std::pair<int,int> E;
+
+  E edges[] = { E(a,c), E(a,d),
+                E(b,a), E(b,d),
+                E(c,f),
+                E(d,c), E(d,e), E(d,f),
+                E(e,b), E(e,g),
+                E(f,e), E(f,g) };
+
+  int weight[] = { 3, 4,
+                   6, 8,
+                   12,
+                   7, 0, 5,
+                   10, 3,
+                   1, 2 };
+
+  for (int i = 0; i < 12; ++i)
+    add_edge(edges[i].first, edges[i].second, weight[i], G);
+
+  print(G, name);
+
+  adjacency_list<listS, vecS, directedS, 
+    property<vertex_color_t, default_color_type> > G_copy(N);
+
+  cout << "Starting graph:" << endl;
+
+  std::ostream_iterator<int> cout_int(std::cout, " ");
+  std::ostream_iterator<char> cout_char(std::cout, " ");
+
+  boost::queue<Vertex> Q;
+  boost::breadth_first_search
+    (G, vertex(a, G), Q,
+     make_bfs_visitor(
+     boost::make_list
+      (write_property(make_iterator_property_map(name, vertex_id,
+                                                name[0]),
+                      cout_char, on_examine_vertex()),
+       write_property(make_iterator_property_map(distance.begin(),
+                                                vertex_id, 
+                                                distance[0]), 
+                      cout_int, on_examine_vertex()),
+       print_edge(make_iterator_property_map(name, vertex_id, 
+                                            name[0]),
+                  std::cout, on_examine_edge()),
+       print_endl(std::cout, on_finish_vertex()))),
+     get(vertex_color, G));
+
+  std::cout << "about to call dijkstra's" << std::endl;
+
+  parent[vertex(a, G)] = vertex(a, G);
+  boost::dijkstra_shortest_paths
+    (G, vertex(a, G), 
+     distance_map(make_iterator_property_map(distance.begin(), vertex_id, 
+                                             distance[0])).
+     predecessor_map(make_iterator_property_map(parent.begin(), vertex_id,
+                                                parent[0])).
+     visitor(make_dijkstra_visitor(copy_graph(G_copy, on_examine_edge()))));
+
+  cout << endl;
+  cout << "Result:" << endl;
+  boost::breadth_first_search
+    (G, vertex(a, G), 
+     visitor(make_bfs_visitor(
+     boost::make_list
+     (write_property(make_iterator_property_map(name, vertex_id,
+                                                name[0]),
+                     cout_char, on_examine_vertex()),
+      write_property(make_iterator_property_map(distance.begin(),
+                                                vertex_id, 
+                                                distance[0]), 
+                     cout_int, on_examine_vertex()),
+      print_edge(make_iterator_property_map(name, vertex_id, 
+                                            name[0]),
+                 std::cout, on_examine_edge()),
+      print_endl(std::cout, on_finish_vertex())))));
+
+  return 0;
+}
+

--- a/test/test_transform_tree.cpp
+++ b/test/test_transform_tree.cpp
@@ -234,6 +234,20 @@ BOOST_AUTO_TEST_CASE(modify_transform_event_test)
     BOOST_CHECK(d->transformModifiedEvent[1].edge == tree.getEdge(b, a));
 }
 
+BOOST_AUTO_TEST_CASE(operations_with_transform)
+{
+    Transform tf1, tf2;
+    tf1.transform.translation << 42, 21, -42;
+    tf1.transform.orientation = base::AngleAxisd(0.25, base::Vector3d::UnitX());
+    tf2.transform.translation << 42, 21, -42;
+    tf2.transform.orientation = base::AngleAxisd(0.25, base::Vector3d::UnitX());
+
+    Transform tf_manual;
+    tf_manual.setTransform(tf1.transform * tf2.transform);
+    Transform tf_operator(tf1 * tf2);
+    BOOST_CHECK(compareTransform(tf_operator, tf_manual));
+}
+
 BOOST_AUTO_TEST_CASE(simple_add_get_transform_test)
 {
     FrameId a = "frame_a";
@@ -251,6 +265,82 @@ BOOST_AUTO_TEST_CASE(simple_add_get_transform_test)
     invTf.setTransform(tf.transform.inverse());
     Transform readTfInv = tree.getTransform(b, a);
     BOOST_CHECK(compareTransform(readTfInv, invTf));
+}
+
+BOOST_AUTO_TEST_CASE(complex_add_get_transform_test)
+{
+
+    FrameId a = "frame_a";
+    FrameId b = "frame_b";
+    FrameId c = "frame_c";
+    FrameId d = "frame_d";
+    TransformGraph tree;
+    Transform tf;
+    tf.transform.translation << 42, 21, -42;
+    tf.transform.orientation = base::AngleAxisd(0.25, base::Vector3d::UnitX());
+    BOOST_CHECK_NO_THROW(tree.addTransform(a, b, tf));
+    BOOST_CHECK_NO_THROW(tree.addTransform(b, c, tf));
+    BOOST_CHECK_NO_THROW(tree.addTransform(a, d, tf));
+    BOOST_CHECK(tree.num_edges() == 6);
+    BOOST_CHECK(tree.num_vertices() == 4);
+
+    /* a -> c **/
+    BOOST_TEST_MESSAGE( "a - > c" );
+    Transform readTf;
+    BOOST_CHECK_NO_THROW(readTf = tree.getTransform(a, c));
+    BOOST_CHECK(compareTransform(readTf, tf*tf));
+
+    /* c -> a **/
+    BOOST_TEST_MESSAGE( "c - > a" );
+    Transform invTf;
+    invTf.setTransform(tf.transform.inverse() * tf.transform.inverse());
+    Transform readTfInv;
+    BOOST_CHECK_NO_THROW(readTfInv = tree.getTransform(c, a));
+    BOOST_CHECK(compareTransform(readTfInv, invTf));
+
+    /* a -> d **/
+    BOOST_TEST_MESSAGE( "a - > d" );
+    BOOST_CHECK_NO_THROW(readTf = tree.getTransform(a, d));
+    BOOST_CHECK(compareTransform(readTf, tf));
+
+    /* c -> d **/
+    BOOST_TEST_MESSAGE( "c - > d" );
+    Transform complexTf;
+    complexTf.setTransform(tf.transform.inverse()*tf.transform.inverse()*tf.transform);
+    BOOST_CHECK_NO_THROW(readTf = tree.getTransform(c, d));
+    BOOST_CHECK(compareTransform(readTf, complexTf));
+
+    /* d -> c **/
+    BOOST_TEST_MESSAGE( "d - > c" );
+    complexTf.setTransform(tf.transform.inverse()*tf.transform*tf.transform);
+    BOOST_CHECK_NO_THROW(readTf = tree.getTransform(d, c));
+    BOOST_CHECK(compareTransform(readTf, complexTf));
+
+    //Close a cycle with an extra frame.
+    //In practice it should not happen in envire
+    FrameId e = "frame_e";
+    BOOST_CHECK_NO_THROW(tree.addTransform(d, e, tf));
+    BOOST_CHECK_NO_THROW(tree.addTransform(e, c, tf));
+
+    /* d -> c **/
+    BOOST_TEST_MESSAGE( "d - > c" );
+    BOOST_CHECK_NO_THROW(readTf = tree.getTransform(d, c));
+    BOOST_CHECK(compareTransform(readTf, tf*tf));
+
+    /* a-> e **/
+    BOOST_TEST_MESSAGE( "a - > e" );
+    BOOST_CHECK_NO_THROW(readTf = tree.getTransform(a, e));
+    BOOST_CHECK(compareTransform(readTf, tf*tf));
+
+    FrameId f = "frame_f";
+    BOOST_CHECK_NO_THROW(tree.addTransform(d, f, tf));
+
+    /* c -> f **/
+    BOOST_TEST_MESSAGE( "c - > f" );
+    BOOST_CHECK_NO_THROW(readTf = tree.getTransform(c, f));
+    complexTf.setTransform(tf.transform.inverse()*tf.transform.inverse()*tf.transform);
+    BOOST_CHECK(compareTransform(readTf, complexTf));
+
 }
 
 


### PR DESCRIPTION
This PR includes the search algorithm to get any Transformation in the Graph. The tricky part wrt a "classical" graph is that transformations do not hold the commutative property. It uses the BFS which behaves like a Dijkstra with no weight in edges. It returns the shortest part between two given Frames. Uni test available and tested. Other minor things included in this PR is to have frameId and frame names to the same value.